### PR TITLE
Only evaluate what we actually need

### DIFF
--- a/model.cc
+++ b/model.cc
@@ -82,12 +82,12 @@ int main() {
   
   // training steps
   for (int i = 0; i < 5000; ++i) {
-    TF_CHECK_OK(session.Run({{x, x_data}, {y, y_data}}, {loss}, &outputs));
     if (i % 100 == 0) {
+      TF_CHECK_OK(session.Run({{x, x_data}, {y, y_data}}, {loss}, &outputs));
       std::cout << "Loss after " << i << " steps " << outputs[0].scalar<float>() << std::endl;
     }
     // nullptr because the output from the run is useless
-    TF_CHECK_OK(session.Run({{x, x_data}, {y, y_data}}, {apply_w1, apply_w2, apply_w3, apply_b1, apply_b2, apply_b3, layer_3}, nullptr));
+    TF_CHECK_OK(session.Run({{x, x_data}, {y, y_data}}, {apply_w1, apply_w2, apply_w3, apply_b1, apply_b2, apply_b3}, nullptr));
   }
 
   // prediction using the trained neural net


### PR DESCRIPTION
After looking at the original code I wasn't sure whether or not you had to seperately evaluate the net to apply training steps, since you seemed to in two different ways. As it turns out you don't. I suggest merging this/updating the tutorial to avoid other people being similarly confused.

For what it's worth it's also about 50% faster on my machine (30s to 20s).